### PR TITLE
Make a fair(er) comparison between blocking and reactive's potential

### DIFF
--- a/non-reactive-app/src/main/resources/application.properties
+++ b/non-reactive-app/src/main/resources/application.properties
@@ -8,3 +8,4 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 
 # db config
 quarkus.datasource.jdbc.url=jdbc:sqlserver://localhost:1433
+quarkus.datasource.jdbc.max-size=200

--- a/reactive-app/src/main/java/org/acme/hibernate/orm/panache/ReactiveFruitResource.java
+++ b/reactive-app/src/main/java/org/acme/hibernate/orm/panache/ReactiveFruitResource.java
@@ -17,7 +17,9 @@ import org.jboss.resteasy.reactive.RestPath;
 
 import io.quarkus.hibernate.reactive.panache.Panache;
 import io.quarkus.panache.common.Sort;
+import io.smallrye.context.api.CurrentThreadContext;
 import io.smallrye.mutiny.Uni;
+import org.eclipse.microprofile.context.ThreadContext;
 
 @Path("fruits")
 @ApplicationScoped
@@ -26,6 +28,7 @@ import io.smallrye.mutiny.Uni;
 public class ReactiveFruitResource {
 
     @GET
+    @CurrentThreadContext(propagated = {}, cleared = {}, unchanged = ThreadContext.ALL_REMAINING)
     public Uni<List<Fruit>> get() {
         return Fruit.listAll(Sort.by("name"));
     }
@@ -33,11 +36,13 @@ public class ReactiveFruitResource {
 
     @GET
     @Path("{id}")
+    @CurrentThreadContext(propagated = {}, cleared = {}, unchanged = ThreadContext.ALL_REMAINING)
     public Uni<Fruit> getSingle(@RestPath Long id) {
         return Fruit.findById(id);
     }
 
     @POST
+    @CurrentThreadContext(propagated = {}, cleared = {}, unchanged = ThreadContext.ALL_REMAINING)
     public Uni<Response> create(Fruit fruit) {
         if (fruit == null || fruit.id != null) {
             throw new WebApplicationException("Id was invalidly set on request.", 422);

--- a/reactive-app/src/main/resources/application.properties
+++ b/reactive-app/src/main/resources/application.properties
@@ -9,3 +9,8 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 # Reactive config
 quarkus.datasource.reactive.url=vertx-reactive:sqlserver://localhost:1433
 quarkus.datasource.reactive.max-size=200
+
+mp.context.ThreadContext.propagated=None
+mp.context.ThreadContext.cleared=None
+mp.context.ThreadContext.unchanged=Remaining
+quarkus.datasource.reactive.cache-prepared-statements=true


### PR DESCRIPTION
An attempt to make the comparison between the reactive and non-reactive stack more fair:
 - disable context propagation in the reactive one (it introduced unnecessary overhead, while the reactive stack doesn't use it)
 - make both connection pools of the same size
 - enable prepared statement caching for both